### PR TITLE
feat: added hyphens for property

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,6 +17,9 @@ cd folksonomy_api
 apt install python3-virtualenv virtualenv virtualenvwrapper
 
 # create and switch to virtualenv
+# if mkvirtualenv command is not found, search for virtualenvwrapper.sh 
+# (/usr/share/virtualenvwrapper/virtualenvwrapper.sh, or /usr/bin/virtualenvwrapper.sh, for example)
+# add the path in your bash profile
 mkvirtualenv folksonomy -p /usr/bin/python3
 workon folksonomy
 
@@ -26,7 +29,7 @@ pip install -r requirements.txt
 # create dbuser if needed
 sudo -u postgres createuser $USER
 
-# create Postgresql database
+# create Postgresql database if needed
 sudo -u postgres createdb folksonomy -O $USER
 psql folksonomy < db/db_setup.sql
 

--- a/folksonomy/api.py
+++ b/folksonomy/api.py
@@ -2,6 +2,7 @@
 
 import os
 import logging
+from logging.handlers import RotatingFileHandler
 from .dependencies import *
 from fastapi.middleware.cors import CORSMiddleware
 

--- a/folksonomy/models.py
+++ b/folksonomy/models.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI, status, Response, Depends, Header
 from pydantic import BaseModel, ValidationError, validator
 
 re_barcode = re.compile(r'[0-9]{1,24}')
-re_key = re.compile(r'[a-z0-9_]+(\:[a-z0-9_]+)*')
+re_key = re.compile(r'[a-z0-9_-]+(\:[a-z0-9_-]+)*')
 
 class User(BaseModel):
     user_id: str
@@ -35,7 +35,7 @@ class ProductTag(BaseModel):
         if not v:
             raise ValueError('k cannot be empty')
         if not re.fullmatch(re_key, v):
-            raise ValueError('k must be alpha-numeric [a-z0-9_:]')
+            raise ValueError('k must be alpha-numeric [a-z0-9_-:]')
         return v
 
     @validator('v')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -244,6 +244,10 @@ def test_post():
             {"product": p['product'], "version": 1, "k": "test_"+str(date), "v": "test"})
         assert response.status_code == 200, f'valid new entry should return 200, got {response.status_code} {response.text}'
 
+        response = client.post("/product", headers=get_auth_token(), json=
+            {"product": p['product'], "version": 1, "k": "a-1:b_2:c-3:d_4", "v": "test"})
+        assert response.status_code == 200, f'lowercase k with hyphen, underscore and number should return 200, got {response.status_code}'
+
 
 @pytest.mark.skipif(skip_auth, reason="skip auth tests")
 def test_put():
@@ -287,6 +291,17 @@ def test_delete():
         response = client.post("/product", headers=get_auth_token(), json={
             "product": p['product'], "version": 1, "k": "test_"+str(date), "v": "test"})
         assert response.status_code == 200, f'valid new entry should return 200, got {response.status_code} {response.text}'
+
+
+@pytest.mark.skipif(skip_auth, reason="skip auth tests")
+def test_ended_clean():
+    p = test_product()[0]
+    with TestClient(app) as client:
+        response = client.delete("/product/"+p['product']+"/test_"+str(date)+"?version=1", headers=get_auth_token(),)
+        assert response.status_code == 200, f'delete created entries for tests should return 200, got {response.status_code} {response.text}'
+
+        response = client.delete("/product/"+p['product']+"/a-1:b_2:c-3:d_4"+"?version=1", headers=get_auth_token(),)
+        assert response.status_code == 200, f'delete created entries for tests should return 200, got {response.status_code} {response.text}'
 
 
 def test_auth_by_cookie():


### PR DESCRIPTION
May solve #132 together with PR (https://github.com/openfoodfacts/openfoodfacts-server/pull/8278)

tested successfully locally

also tested with pytest
tests are done with a key="test_"+date, except tests for keys.
tests for keys were only for non-"200" response, to create a test expecting "200"-response (key containing expected character, including hyphen, for example), it needs to delete the record at the end of the tests, otherwise next time we run pytest locally, it would break. This is done in a new block called "test_ended_clean"
=> need someone to review that this is properly done.

Although it is not related to the issue, the last test in the delete block add a new record in the database. This latter is now also deleted in the "test_ended_clean" block. That ways, running pytest do not leave any record in the database.

Also not related to the issue, added more details for install (may be helpful for others)

Also not related to the issue, when running pytests, there was an "AttributeError: module 'logging' has no attribute 'handlers'" error that was solved by adding an import.

