### PR TITLE
feat: new auth to enable other instances auth

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,22 +40,25 @@ psql folksonomy < db/db_setup.sql
 ```
 uvicorn folksonomy.api:app --reload
 ```
-or use `--host` if you want to make it available on your local network, eg.:
+or use `--host` if you want to make it available on your local network:
 ```
-uvicorn folksonomy.api:app --reload --host 192.168.0.100
+uvicorn folksonomy.api:app --reload --host <you-ip-address>
 ```
 
 ## Run with a local instance of Product Opener
 
 To deal with CORS and/or `401 Unauthorized` issues when running in a dev environment you have to deal with two things:
+
 * both Folksonomy Engine server and Product Opener server have to run on the same domain (openfoodfacts.localhost by default for Product Opener)
 * to allow authentication with the Product Opener cookie, you must tell Folksonomy Engine to use the local Product Opener instance as the authent server
 
 To do so you can:
-* add an environment variable, `AUTH_URL` to specify the auth server
+* edit the `local_settings.py` (copying from `local_settings_example.py`) and uncomment proposed AUTH_PREFIX and FOLKSONOMY_PREFIX entries
 * use a the same host name as Product Opener when launching Folksonomy Engine server
 
-This should work:
+This then should work:
 ```
-AUTH_URL="http://fr.openfoodfacts.localhost" uvicorn folksonomy.api:app --host 'api.fr.openfoodfacts.localhost' --reload
+uvicorn folksonomy.api:app --host 127.0.0.1 --reload --port 8888
 ```
+
+You can then access the API at http://api.folksonomy.openfoodfacts.localhost:8888/docs

--- a/folksonomy/api.py
+++ b/folksonomy/api.py
@@ -136,8 +136,6 @@ def get_auth_server(request: Request):
     We deduce it by changing part of the request base URL
     according to FOLKSONOMY_PREFIX and AUTH_PREFIX settings
     """
-    if request is None:
-        raise HTTPException("Can't get auth server URL from None request")
     base_url =  f"{request.base_url.scheme}://{request.base_url.netloc}"
     # remove folksonomy prefix and add AUTH prefix
     base_url = base_url.replace(settings.FOLKSONOMY_PREFIX or "", settings.AUTH_PREFIX or "")

--- a/folksonomy/api.py
+++ b/folksonomy/api.py
@@ -129,8 +129,23 @@ def check_owner_user(user: User, owner, allow_anonymous=False):
     return
 
 
+def get_auth_server(request: Request):
+    """
+    Get auth server URL from request
+
+    We deduce it by changing part of the request base URL
+    according to FOLKSONOMY_PREFIX and AUTH_PREFIX settings
+    """
+    if request is None:
+        raise HTTPException("Can't get auth server URL from None request")
+    base_url =  f"{request.base_url.scheme}://{request.base_url.netloc}"
+    # remove folksonomy prefix and add AUTH prefix
+    base_url = base_url.replace(settings.FOLKSONOMY_PREFIX or "", settings.AUTH_PREFIX or "")
+    return base_url
+
+
 @app.post("/auth")
-async def authentication(response: Response, form_data: OAuth2PasswordRequestForm = Depends()):
+async def authentication(request: Request, response: Response, form_data: OAuth2PasswordRequestForm = Depends()):
     """
     Authentication: provide user/password and get a bearer token in return
 
@@ -143,7 +158,7 @@ async def authentication(response: Response, form_data: OAuth2PasswordRequestFor
     user_id = form_data.username
     password = form_data.password
     token = user_id+'__U'+str(uuid.uuid4())
-    auth_url = settings.AUTH_SERVER + "/cgi/auth.pl"
+    auth_url = get_auth_server(request) + "/cgi/auth.pl"
     auth_data={'user_id': user_id, 'password': password}
     async with aiohttp.ClientSession() as http_session:
         async with http_session.post(auth_url, data=auth_data) as resp:
@@ -167,7 +182,7 @@ async def authentication(response: Response, form_data: OAuth2PasswordRequestFor
 
 
 @app.post("/auth_by_cookie")
-async def authentication(response: Response, session: Optional[str] = Cookie(None)):
+async def authentication(request: Request, response: Response, session: Optional[str] = Cookie(None)):
     """
     Authentication: provide Open Food Facts session cookie and get a bearer token in return
 
@@ -187,7 +202,7 @@ async def authentication(response: Response, session: Optional[str] = Cookie(Non
         raise HTTPException(
             status_code=422, detail="Malformed 'session' cookie")
 
-    auth_url = settings.AUTH_SERVER + "/cgi/auth.pl"
+    auth_url = get_auth_server(request) + "/cgi/auth.pl"
     async with aiohttp.ClientSession() as http_session:
         async with http_session.post(auth_url, cookies={'session': session}) as resp:
             status_code = resp.status

--- a/folksonomy/settings.py
+++ b/folksonomy/settings.py
@@ -7,10 +7,10 @@ POSTGRES_HOST = os.environ.get("POSTGRES_HOST", None) # Change if necessary
 POSTGRES_DATABASE = os.environ.get("POSTGRES_DATABASE", 'folksonomy')
 
 
-# If you're in dev, you can specify another auth_server; eg.
-#   AUTH_URL="http://localhost.openfoodfacts" uvicorn folksonomy.api:app --host
-# Otherwise it defaults to https://world.openfoodfacts.org
-AUTH_SERVER = os.environ.get("AUTH_URL", "https://world.openfoodfacts.org")
+# we deduce the URL to which to authenticate from the base url,
+# with some changes in the prefixes, substituing FOLKSONOMY_PREFIX by AUTH_PREFIX
+FOLKSONOMY_PREFIX = os.environ.get("FOLKSONOMY_PREFIX", "api.folksonomy")
+AUTH_PREFIX = os.environ.get("AUTH_PREFIX", "world")
 
 # time (in seconds) to wait for after a failed authentication attempt (to avoid brute force)
 FAILED_AUTH_WAIT_TIME = 2  # this settings is meant to be overridden by tests only

--- a/local_settings_example.py
+++ b/local_settings_example.py
@@ -7,3 +7,8 @@ POSTGRES_USER = '' # Leave empty if no user exists for database
 POSTGRES_PASSWORD = '' # Leave empty if no password exists for user
 POSTGRES_HOST = '' # Change if necessary
 POSTGRES_DATABASE = 'folksonomy/'
+
+# for dev using a local product opener instance you can use this
+# base domain has to be the same (see INSTALL.md)
+#FOLKSONOMY_PREFIX="api.folksonomy.openfoodfacts.localhost:8888"
+#AUTH_PREFIX="world.openfoodfacts.localhost"


### PR DESCRIPTION
That is if you make folksonomy api available at api.folksonomy.openbeautyfacts.org you will be able to authenticate against world.openbeautyfacts.org
