### PR TITLE
fix: Returns a JSON response if desired result is not found

### DIFF
--- a/folksonomy/api.py
+++ b/folksonomy/api.py
@@ -293,11 +293,7 @@ async def product_stats(response: Response,
     # import pdb;pdb.set_trace()
 
     if not out or not out[0]:
-        return JSONResponse(
-            status_code=200,
-            content={"message": "No products found matching the given filters."},
-            headers={"x-pg-timing": timing}
-        )
+        return []
 
     return JSONResponse(status_code=200, content=out[0], headers={"x-pg-timing":timing})
 
@@ -350,11 +346,7 @@ async def product_tags_list(response: Response,
     out = await cur.fetchone()
 
     if not out or not out[0]:
-        return JSONResponse(
-            status_code=200,
-            content={"message": "No product found matching the given tags."},
-            headers={"x-pg-timing": timing}
-        )
+        return []
     
     return JSONResponse(status_code=200, content=out[0], headers={"x-pg-timing": timing})
 

--- a/folksonomy/api.py
+++ b/folksonomy/api.py
@@ -292,11 +292,11 @@ async def product_stats(response: Response,
     # out2 = await cur.fetchone()
     # import pdb;pdb.set_trace()
 
-    if not out or not out[0]:
-        return []
-
-    return JSONResponse(status_code=200, content=out[0], headers={"x-pg-timing":timing})
-
+    return JSONResponse(
+        status_code=200,
+        content=out[0] if out and out[0] is not None else [],
+        headers={"x-pg-timing": timing}
+    )
 
 @app.get("/products", response_model=List[ProductList])
 async def product_list(response: Response,
@@ -324,8 +324,12 @@ async def product_list(response: Response,
         params
     )
     out = await cur.fetchone()
-    return JSONResponse(status_code=200, content=out[0], headers={"x-pg-timing":timing})
 
+    return JSONResponse(
+        status_code=200,
+        content=out[0] if out and out[0] is not None else [],
+        headers={"x-pg-timing": timing}
+    )
 
 @app.get("/product/{product}", response_model=List[ProductTag])
 async def product_tags_list(response: Response,
@@ -345,12 +349,12 @@ async def product_tags_list(response: Response,
     )
     out = await cur.fetchone()
 
-    if not out or not out[0]:
-        return []
+    return JSONResponse(
+        status_code=200,
+        content=out[0] if out and out[0] is not None else [],
+        headers={"x-pg-timing": timing}
+    )
     
-    return JSONResponse(status_code=200, content=out[0], headers={"x-pg-timing": timing})
-
-
 @app.get("/product/{product}/{k}", response_model=ProductTag)
 async def product_tag(response: Response,
                       product: str, k: str, owner='',
@@ -387,10 +391,12 @@ async def product_tag(response: Response,
             (product, owner, key),
         )
     out = await cur.fetchone()
-    if out:
-        return JSONResponse(status_code=200, content=out[0], headers={"x-pg-timing": timing})
-    else:
-        return JSONResponse(status_code=404, content=None)
+    
+    return JSONResponse(
+        status_code=200,
+        content=out[0] if out and out[0] is not None else [],
+        headers={"x-pg-timing": timing}
+    )
 
 
 @app.get("/product/{product}/{k}/versions", response_model=List[ProductTag])
@@ -415,7 +421,13 @@ async def product_tag_list_versions(response: Response,
         (product, owner, k),
     )
     out = await cur.fetchone()
-    return JSONResponse(status_code=200, content=out[0], headers={"x-pg-timing": timing})
+
+    return JSONResponse(
+        status_code=200,
+        content=out[0] if out and out[0] is not None else [],
+        headers={"x-pg-timing": timing}
+    )
+    
 
 
 @app.post("/product")
@@ -575,8 +587,12 @@ async def keys_list(response: Response,
         (owner,)
     )
     out = await cur.fetchone()
-    return JSONResponse(status_code=200, content=out[0], headers={"x-pg-timing": timing})
 
+    return JSONResponse(
+        status_code=200,
+        content=out[0] if out and out[0] is not None else [],
+        headers={"x-pg-timing": timing}
+    )
 
 @app.get("/values/{k}")
 async def get_unique_values(response: Response,

--- a/folksonomy/api.py
+++ b/folksonomy/api.py
@@ -291,6 +291,14 @@ async def product_stats(response: Response,
     # )
     # out2 = await cur.fetchone()
     # import pdb;pdb.set_trace()
+
+    if not out or not out[0]:
+        return JSONResponse(
+            status_code=200,
+            content={"message": "No products found matching the given filters."},
+            headers={"x-pg-timing": timing}
+        )
+
     return JSONResponse(status_code=200, content=out[0], headers={"x-pg-timing":timing})
 
 
@@ -340,6 +348,14 @@ async def product_tags_list(response: Response,
         (product, owner),
     )
     out = await cur.fetchone()
+
+    if not out or not out[0]:
+        return JSONResponse(
+            status_code=200,
+            content={"message": "No product found matching the given tags."},
+            headers={"x-pg-timing": timing}
+        )
+    
     return JSONResponse(status_code=200, content=out[0], headers={"x-pg-timing": timing})
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -297,8 +297,7 @@ def test_product_missing(with_sample):
     with TestClient(app) as client:
         response = client.get("/product/0000000000000")
         assert response.status_code == 200
-        assert response.json() == None
-        return response.json()
+        assert response.json() == []
 
 
 def test_product_key(with_sample):
@@ -326,8 +325,8 @@ def test_key_stripped_on_get(with_sample):
 def test_product_key_missing(with_sample):
     with TestClient(app) as client:
         response = client.get(f"/product/{BARCODE_1}/not-existing")
-        assert response.status_code == 404
-        assert response.json() == None
+        assert response.status_code == 200
+        assert response.json() == []
 
 
 def test_product_key_versions(with_sample):
@@ -350,7 +349,7 @@ def test_product_key_versions_missing(with_sample):
     with TestClient(app) as client:
         response = client.get(f"/product/{BARCODE_3}/not-existing/versions")
         assert response.status_code == 200
-        assert response.json() == None
+        assert response.json() == []
 
 
 def test_products_stats_key(with_sample):


### PR DESCRIPTION
### What
If I use the stats API with a non-existent key or value, I get a null back instead of a JSON response.

### Solution 
Returns - [] for all GET API responses if the desired output is not found

### Screenshot
![image](https://github.com/user-attachments/assets/84eb0ff2-e341-4125-afb2-b85483d40afc)


### Fixes bug(s)
- https://github.com/openfoodfacts/folksonomy_api/issues/120
- https://github.com/openfoodfacts/folksonomy_api/issues/241
- https://github.com/openfoodfacts/folksonomy_api/issues/107
