### PR TITLE
fix: PUT API response does not send ValidationError when expected

### DIFF
--- a/folksonomy/api.py
+++ b/folksonomy/api.py
@@ -442,7 +442,7 @@ async def product_tag_add(response: Response,
     return
 
 
-def create_version_error(expected_version: int, received_version: int):
+def _create_version_error(expected_version: int, received_version: int):
     return HTTPException(
         status_code=422,
         detail=[

--- a/folksonomy/api.py
+++ b/folksonomy/api.py
@@ -489,7 +489,7 @@ async def product_tag_update(response: Response,
 
         # Validate version increment
         if product_tag.version != latest_version + 1:
-            raise create_version_error(latest_version + 1, product_tag.version)
+            raise _create_version_error(latest_version + 1, product_tag.version)
 
         req, params = db.update_product_tag_req(product_tag)
         cur, timing = await db.db_exec(req, params)

--- a/folksonomy/api.py
+++ b/folksonomy/api.py
@@ -497,13 +497,10 @@ async def product_tag_update(response: Response,
             status_code=422,
             detail=re.sub(r'.*@@ (.*) @@\n.*$', r'\1', e.pgerror)[:-1],
         )
+    # Check if exactly one row was updated
+    # Atlease one row will be updated, as version is checked
     if cur.rowcount == 1:
         return "ok"
-    elif cur.rowcount == 0:  # non existing key
-        raise HTTPException(
-            status_code=404,
-            detail="Key was not found",
-        )
     else:
         raise HTTPException(
             status_code=503,


### PR DESCRIPTION
### What
Fix the issue described in #117. The API previously just sent `{"detail":"next version must be equal to 2, was 1"}` instead of a ValidationError. Now the endpoint first fetches the current version from db, and send a validation error back if the version is not properly incremented.

### Screenshot
```json
{
  "detail": [
    {
      "type": "value_error",
      "loc": [
        "body",
        "version"
      ],
      "msg": "Value error, version must be exactly 2",
      "input": 4
    }
  ]
}
```

### Fixes bug(s)
- #117
