### PR TITLE
feat: Add response models (PUT/POST/DELETE endpoints untouched)

### DIFF
--- a/folksonomy/api.py
+++ b/folksonomy/api.py
@@ -75,7 +75,7 @@ async def initialize_transactions(request: Request, call_next):
         return response
 
 
-@app.get("/", status_code=status.HTTP_200_OK)
+@app.get("/", status_code=status.HTTP_200_OK, response_model=HelloResponse)
 async def hello():
     return {"message": "Hello folksonomy World! Tip: open /docs for documentation"}
 
@@ -146,7 +146,7 @@ def get_auth_server(request: Request):
     return base_url
 
 
-@app.post("/auth")
+@app.post("/auth", response_model=TokenResponse)
 async def authentication(request: Request, response: Response, form_data: OAuth2PasswordRequestForm = Depends()):
     """
     Authentication: provide user/password and get a bearer token in return
@@ -195,7 +195,7 @@ async def authentication(request: Request, response: Response, form_data: OAuth2
         status_code=500, detail="Server error")
 
 
-@app.post("/auth_by_cookie")
+@app.post("/auth_by_cookie", response_model=TokenResponse)
 async def authentication(request: Request, response: Response, session: Optional[str] = Cookie(None)):
     """
     Authentication: provide Open Food Facts session cookie and get a bearer token in return
@@ -570,7 +570,7 @@ async def keys_list(response: Response,
     return JSONResponse(status_code=200, content=out[0], headers={"x-pg-timing": timing})
 
 
-@app.get("/values/{k}")
+@app.get("/values/{k}", response_model=List[ValueCount])
 async def get_unique_values(response: Response,
                             k: str,
                             owner: str = '',
@@ -622,7 +622,7 @@ async def get_unique_values(response: Response,
     return JSONResponse(status_code=200, content=data, headers={"x-pg-timing": timing})
 
 
-@app.get("/ping")
+@app.get("/ping", response_model=PingResponse)
 async def pong(response: Response):
     """
     Check server health

--- a/folksonomy/api.py
+++ b/folksonomy/api.py
@@ -478,7 +478,7 @@ async def product_tag_update(response: Response,
     else:
         raise HTTPException(
             status_code=503,
-            detail="Doubious update - more than one row udpated",
+            detail="Dubious update - more than one row udpated",
         )
 
 

--- a/folksonomy/dependencies.py
+++ b/folksonomy/dependencies.py
@@ -17,5 +17,15 @@ from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from pydantic import BaseModel, ValidationError, validator
 
 # folksonomy imports
-from .models import ProductTag, ProductStats, User, ProductList, KeyStats
+from .models import (
+    ProductTag,
+    ProductStats,
+    User,
+    ProductList,
+    HelloResponse,
+    TokenResponse,
+    KeyStats,
+    PingResponse,
+    ValueCount,
+)
 

--- a/folksonomy/models.py
+++ b/folksonomy/models.py
@@ -68,7 +68,26 @@ class ProductList(BaseModel):
     k:          str
     v:          str
     
+
+class HelloResponse(BaseModel):
+    message: str
+
+    
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str
+    
+
 class KeyStats(BaseModel):
     k: str 
     count: int  
     values: int
+
+
+class ValueCount(BaseModel):
+    v: str
+    product_count: int
+
+
+class PingResponse(BaseModel):
+    ping: str


### PR DESCRIPTION
### What
This PR adds proper response models for all endpoints to ensure the FastAPI documentation accurately represents the actual response structure. Follow-up to #231.

### Changes

- Added `HelloResponse` model for root endpoint
- Added `TokenResponse` model for auth endpoints
- Added `PingResponse` model for /ping endpoint
- Added `ValueCount` model for /values endpoint
- Minor typo in an error response

These changes improve the documentation accuracy in the OpenAPI spec and potentially type safety for the API.

### Fixes bug(s)
Fixes #118 
