### PR TITLE
fix: Add status response model for POST/PUT/DELETE endpoints

### DIFF
--- a/folksonomy/api.py
+++ b/folksonomy/api.py
@@ -410,7 +410,7 @@ async def product_tag_list_versions(response: Response,
     return JSONResponse(status_code=200, content=out[0], headers={"x-pg-timing": timing})
 
 
-@app.post("/product")
+@app.post("/product", response_model=StatusResponse)
 async def product_tag_add(response: Response,
                           product_tag: ProductTag,
                           user: User = Depends(get_current_user)):
@@ -439,11 +439,11 @@ async def product_tag_add(response: Response,
         return JSONResponse(status_code=422, content={"detail": {"msg": error_msg}})
 
     if cur.rowcount == 1:
-        return "ok"
+        return {"status": "ok"}
     return
 
 
-@app.put("/product")
+@app.put("/product", response_model=StatusResponse)
 async def product_tag_update(response: Response,
                              product_tag: ProductTag,
                              user: User = Depends(get_current_user)):
@@ -469,7 +469,7 @@ async def product_tag_update(response: Response,
             detail=re.sub(r'.*@@ (.*) @@\n.*$', r'\1', e.pgerror)[:-1],
         )
     if cur.rowcount == 1:
-        return "ok"
+        return {"status": "ok"}
     elif cur.rowcount == 0:  # non existing key
         raise HTTPException(
             status_code=404,
@@ -482,7 +482,7 @@ async def product_tag_update(response: Response,
         )
 
 
-@app.delete("/product/{product}/{k}")
+@app.delete("/product/{product}/{k}", response_model=StatusResponse)
 async def product_tag_delete(response: Response,
                              product: str, k: str, version: int, owner='',
                              user: User = Depends(get_current_user)):
@@ -519,7 +519,7 @@ async def product_tag_delete(response: Response,
         (product, owner, k.lower()),
     )
     if cur.rowcount == 1:
-        return "ok"
+        return {"status": "ok"}
     else:
         # we have a conflict, return an error explaining conflict
         cur, timing = await db.db_exec(

--- a/folksonomy/dependencies.py
+++ b/folksonomy/dependencies.py
@@ -17,5 +17,5 @@ from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from pydantic import BaseModel, ValidationError, validator
 
 # folksonomy imports
-from .models import ProductTag, ProductStats, User, ProductList, KeyStats
+from .models import ProductTag, ProductStats, User, ProductList, KeyStats, StatusResponse
 

--- a/folksonomy/models.py
+++ b/folksonomy/models.py
@@ -72,3 +72,8 @@ class KeyStats(BaseModel):
     k: str 
     count: int  
     values: int
+    
+
+class StatusResponse(BaseModel):
+    status: str
+    message: Optional[str] = None


### PR DESCRIPTION
### What
**This change modifies the API.** As per recommendations in thread https://github.com/openfoodfacts/folksonomy_api/pull/231#discussion_r1978984237, #231 was split into this PR which changes the API.

### Changes
- Added a status response model to convert simple "ok" returns on success of POST, PUT, and DELETE endpoints into a proper Pydantic model

### Related Issues
Partially fixes concern raised in #119 regarding having multiple return types. https://github.com/openfoodfacts/folksonomy_api/pull/231#discussion_r1976802233 is my reasoning behind why we should have standardization within each endpoint and across the API.