### PR TITLE
ci: Fix pytest-asyncio deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,7 @@ pytest = "^8.3.5"
 pytest-asyncio = "^0.25.3"
 pytest-cov = "^6.0.0"
 httpx = "^0.28.1"
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+asyncio_default_fixture_loop_scope = "function"


### PR DESCRIPTION
**Signed-off-by:** Areeb Ahmed [areebshariff@acm.org](mailto:areebshariff@acm.org)

## Summary of Changes

- Set `asyncio_mode` to `"strict"`
- Set `asyncio_default_fixture_loop_scope` to `"function"` in `pyproject.toml` to resolve the `PytestDeprecationWarning` during GitHub CI test runs.

## Related Issue(s)
Closes #264

## Screenshots

Before

![image](https://github.com/user-attachments/assets/655e9a94-140f-4403-aef5-995bef6dac29)

After

![image](https://github.com/user-attachments/assets/c609f84f-c47f-43fe-95d2-9918ac155540)
