### PR TITLE
docs: Add command lines in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,6 +15,10 @@ apt install git sudo postgresql python3-pip curl -y
 # Install Poetry
 curl -sSL https://install.python-poetry.org | python3 -
 
+# Add Poetry to the PATH (Optional)
+echo 'export PATH="/root/.local/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+
 # Create a user for the application (optional but recommended)
 adduser folksonomy
 usermod -aG sudo folksonomy


### PR DESCRIPTION
### What
- Add optional command lines in `INSTALL.md` 
(Adding the Poetry installation directory to the system's PATH environment variable.)

Before
```
# Start with a fresh Debian 12 install, logged as root
apt install git sudo postgresql python3-pip curl -y

# Install Poetry
curl -sSL https://install.python-poetry.org | python3 -
```
After
```
# Start with a fresh Debian 12 install, logged as root
apt install git sudo postgresql python3-pip curl -y

# Install Poetry
curl -sSL https://install.python-poetry.org | python3 -

# Add Poetry to the PATH (Optional)
echo 'export PATH="/root/.local/bin:$PATH"' >> ~/.bashrc
source ~/.bashrc
```



### Fixes bug(s)
- #154 

