### PR TITLE
fix: pytest error with connection leak

### DIFF
--- a/folksonomy/db.py
+++ b/folksonomy/db.py
@@ -36,7 +36,7 @@ class NotInAsyncIOError(Exception):
 async def get_conn():
     """Get current database connection, creating it if needed"""
     global conn
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     if loop is None:
         raise NotInAsyncIOError("This method only works with asyncio")
     _conn = conn.get(loop)
@@ -63,7 +63,7 @@ def cursor():
 async def terminate():
     """Close all database connection"""
     global conn
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     _conn = conn.get(loop)
     if _conn is not None:
         _conn.terminate()


### PR DESCRIPTION
### What
1. Modified deprecated `get_event_loop()` to new `get_running_loop()`. [source](https://docs.python.org/3/library/asyncio-eventloop.html)
2. Reusing the `TestClient` instance to avoid connection leaks.
3. Removed usage of `asyncio.run()` because it creates new loops that can lead to connection leaks.

### Screenshot
Now when I run the tests it works:
![Screenshot from 2025-04-01 17-43-03](https://github.com/user-attachments/assets/c41f30f5-9a2c-472d-b789-9b07a8b40932)


And I even tried adding a bunch of dummy tests to see if it would crash if I added more... It worked fine:
![Screenshot from 2025-04-01 17-26-49](https://github.com/user-attachments/assets/919f05cc-32bb-45d8-a11d-dbc90714593b)


### Fixes bug(s)
#269 
