### PR TITLE
fix: adds correct container name to readme setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ It requires minimal setup and ensures a consistent development environment.
 
 3. Eventually create the shared network (it might already exist if you develop with [openfoodfacts-server](https://github.com/openfoodfacts/openfoodfacts-server/pulls))
    ```bash
-   docker network create po_default
+   docker network create po_off_default
    ```
 
 4. Start the services:


### PR DESCRIPTION
### What
- adds correct container name for readme instructions setup 
