### PR TITLE
feat: make PostgreSQL port configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ COPY . .
 # --- GENERATE START SCRIPT ---
 RUN tee /app/start.sh <<-'EOF'
 #!/bin/bash
-while ! nc -z "$POSTGRES_HOST" 5432; do
+while ! nc -z "$POSTGRES_HOST" "${POSTGRES_PORT:-5432}"; do
   echo "Waiting for PostgreSQL at $POSTGRES_HOST..."
   sleep 1
 done

--- a/folksonomy/db.py
+++ b/folksonomy/db.py
@@ -45,6 +45,7 @@ async def get_conn():
             user=settings.POSTGRES_USER,
             password=settings.POSTGRES_PASSWORD,
             host=settings.POSTGRES_HOST,
+            port=settings.POSTGRES_PORT,
             async_=True,
         )
         conn[loop] = _conn

--- a/folksonomy/settings.py
+++ b/folksonomy/settings.py
@@ -9,6 +9,7 @@ POSTGRES_PASSWORD = os.environ.get(
 )  # Leave empty if no password exists for user
 POSTGRES_HOST = os.environ.get("POSTGRES_HOST", None)  # Change if necessary
 POSTGRES_DATABASE = os.environ.get("POSTGRES_DATABASE", "folksonomy")
+POSTGRES_PORT = os.environ.get("POSTGRES_PORT", 5432)
 
 
 # we deduce the URL to which to authenticate from the base url,


### PR DESCRIPTION
The database connection pool currently relies on the driver default PostgreSQL port, which prevents deployments from selecting a non-standard port through environment configuration.

This adds `POSTGRES_PORT`, defaulting to `5432`, and passes it to `aiopg.create_pool`.

Validation:

- `python -m compileall -q folksonomy`
- Verified `POSTGRES_PORT=5433` is read from the environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PostgreSQL connections now use the configured port.
  * Startup readiness checks respect the configured PostgreSQL port instead of assuming the default.

* **Configuration**
  * Added support for setting the PostgreSQL port through the `POSTGRES_PORT` environment variable, defaulting to `5432`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->